### PR TITLE
Subscription callback was not executed in a predictable way.

### DIFF
--- a/client/templates/social.coffee
+++ b/client/templates/social.coffee
@@ -1,6 +1,7 @@
 Template.reactionSocial.onCreated ->
   _self = this
-  @subscribe "Packages", ->
+  subscription = @subscribe "Packages"
+  if subscription.ready()
     _self.socialSettings = ReactionCore.Collections.Packages.findOne({name: 'reaction-social'}).settings.public
 
 Template.reactionSocial.helpers

--- a/client/templates/social.coffee
+++ b/client/templates/social.coffee
@@ -1,8 +1,9 @@
 Template.reactionSocial.onCreated ->
   _self = this
-  subscription = @subscribe "Packages"
-  if subscription.ready()
-    _self.socialSettings = ReactionCore.Collections.Packages.findOne({name: 'reaction-social'}).settings.public
+  @autorun () ->
+    subscription = _self.subscribe "Packages"
+    if subscription.ready()
+      _self.socialSettings = ReactionCore.Collections.Packages.findOne({name: 'reaction-social'}).settings.public
 
 Template.reactionSocial.helpers
   settings: -> # this settings would be available in all social apps. e.g. facebook.html


### PR DESCRIPTION
 Use subsciption.ready() instead.

Without subscription.ready() the settings.public part of the social
package was not assigned reliably to _self.socialSettings, because the
callback was not always executed.

The result was that the social icons did not appear in the footer.

With subscription.ready() _self.socialSettings is assigned in a reliable way which in turn then
triggers template rendering to display the social icons in the footer.